### PR TITLE
Use ECR digest for deployments

### DIFF
--- a/.github/workflows/deploy-helm.yaml
+++ b/.github/workflows/deploy-helm.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Helm
         uses: azure/setup-helm@v3
 
-      - name: Login to ECR
+      - name: Pull Image Hash
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 

--- a/.github/workflows/deploy-helm.yaml
+++ b/.github/workflows/deploy-helm.yaml
@@ -23,13 +23,26 @@ jobs:
       - name: Setup Helm
         uses: azure/setup-helm@v3
 
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Fetch image digest
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+        run: |
+          REPO_NAME=${ECR_REPOSITORY#*.amazonaws.com/}
+          IMAGE_DIGEST=$(aws ecr describe-images --repository-name "$REPO_NAME" --image-ids imageTag=latest --query 'imageDetails[0].imageDigest' --output text)
+          echo "IMAGE_DIGEST=$IMAGE_DIGEST" >> "$GITHUB_ENV"
+
       - name: Deploy Helm chart
         run: |
           helm upgrade --install k8s-api ./_infra/k8s-api-chart \
             --namespace api \
             --create-namespace \
             --values ./_infra/k8s-api-chart/values.yaml \
-            --set image.tag=latest \
+            --set image.digest=$IMAGE_DIGEST \
             --set ingress.hosts[0].host=${{ secrets.INGRESS_HOST }} \
             --set image.repository=${{ secrets.ECR_REPOSITORY }}
 

--- a/.github/workflows/gitops-sync.yaml
+++ b/.github/workflows/gitops-sync.yaml
@@ -42,6 +42,8 @@ jobs:
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          IMAGE_DIGEST=$(docker inspect --format='{{ index .RepoDigests 0 }}' $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG | cut -d'@' -f2)
+          echo "IMAGE_DIGEST=$IMAGE_DIGEST" >> "$GITHUB_ENV"
 
       # 3. Install Helm CLI
       - name: Set up Helm
@@ -58,7 +60,7 @@ jobs:
           helm template k8s-api ./_infra/k8s-api-chart \
             --namespace api \
             --values ./_infra/k8s-api-chart/values.yaml \
-            --set image.tag=latest \
+            --set image.digest=$IMAGE_DIGEST \
             --set ingress.hosts[0].host=${{ secrets.INGRESS_HOST }} \
             --set image.repository=${{ secrets.ECR_REPOSITORY }} \
             --output-dir "$TMP_OUT"
@@ -99,6 +101,6 @@ jobs:
           if git diff --cached --quiet; then
             echo "No manifest changes to push"
           else
-            git commit -m "ci: sync k8s-api manifests @ ${{ github.sha }}"
+            git commit -m "ci: sync k8s-api manifests ${IMAGE_DIGEST}"
             git push origin main
           fi

--- a/.github/workflows/gitops-sync.yaml
+++ b/.github/workflows/gitops-sync.yaml
@@ -1,6 +1,5 @@
 name: Sync k8s-API Manifests to GitOps Repo
 
-# <-- Make sure this 'on:' is at the very left margin (no indent).
 on:
   push:
     branches:
@@ -10,11 +9,9 @@ jobs:
   render-and-push:
     runs-on: ubuntu-latest
     steps:
-      # 1. Checkout this k8s-api repo
       - name: Checkout k8s-api repo
         uses: actions/checkout@v3
 
-      # 2. Checkout your GitOps repo
       - name: Checkout GitOps repo
         uses: actions/checkout@v3
         with:
@@ -22,7 +19,6 @@ jobs:
           token:      ${{ secrets.GITOPS_TOKEN }}
           path:       gitops
 
-      # 3. Configure AWS Credentials
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -45,11 +41,9 @@ jobs:
           IMAGE_DIGEST=$(docker inspect --format='{{ index .RepoDigests 0 }}' $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG | cut -d'@' -f2)
           echo "IMAGE_DIGEST=$IMAGE_DIGEST" >> "$GITHUB_ENV"
 
-      # 3. Install Helm CLI
       - name: Set up Helm
         uses: azure/setup-helm@v3
 
-      # 4. Render chart into individual files under gitops/apps/k8s-api
       - name: Render k8s-api manifests as individual files
         run: |
           # 4a. Create a temporary output directory

--- a/_infra/k8s-api-chart/templates/deployment.yaml
+++ b/_infra/k8s-api-chart/templates/deployment.yaml
@@ -15,7 +15,11 @@ spec:
     spec:
       containers:
         - name: {{ include "k8s-api-chart.fullname" . }}
+{{- if .Values.image.digest }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+{{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/_infra/k8s-api-chart/values.yaml
+++ b/_infra/k8s-api-chart/values.yaml
@@ -3,6 +3,7 @@ replicaCount: 1
 image:
   repository: account-number.dkr.ecr.region.amazonaws.com/my/api
   tag: latest
+  digest: ""
   pullPolicy: Always
 
 resources:


### PR DESCRIPTION
## Summary
- add digest field in Helm values and support digest in deployment template
- capture the pushed image digest in gitops workflow and template manifests with that digest
- fetch latest digest in helm deploy workflow and upgrade using that digest

## Testing
- `go test ./...` *(fails: access to Go modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68824c84c698832e932838935535435e